### PR TITLE
[WIP] Trying out fix for the SSR issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "next/babel",
+      {
+        "preset-react": {
+          "runtime": "automatic",
+          "importSource": "@emotion/react"
+        }
+      }
+    ]
+  ],
+  "plugins": ["@emotion/babel-plugin"]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emotion/babel-plugin": "^11.3.0",
     "@emotion/react": "^11.4.0",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.3.0",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -34,7 +34,7 @@ MyDocument.getInitialProps = async (ctx) => {
   const originalRenderPage = ctx.renderPage;
 
   const cache = getCache();
-  const { extractCriticalToChunks, extractCritical } = createEmotionServer(cache);
+  const { extractCriticalToChunks } = createEmotionServer(cache);
 
   ctx.renderPage = () =>
     originalRenderPage({
@@ -57,18 +57,12 @@ MyDocument.getInitialProps = async (ctx) => {
       dangerouslySetInnerHTML={{ __html: style.css }}
     />
   ));
-
-  let { css, ids } = extractCritical(initialProps.html);
-  const dataEmtion = `css ${ids.join(' ')}`;
-  const emotionCssStyleTag = <style key="emotion-css-style-tag" data-emotion={dataEmtion}>{css}</style>
-
   return {
     ...initialProps,
     userLanguage: ctx.query.userLanguage || 'en',
     // Styles fragment is rendered after the app and page rendering finish.
     styles: [
       ...emotionStyleTags,
-      emotionCssStyleTag,
     ],
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import Stack from '@material-ui/core/Stack';
 import { styled, useTheme } from '@material-ui/core';
-import { createUseClassNamesFactory } from 'tss-react';
+// This is the css util exported in @emotion/react
+import { css } from '@material-ui/system';
+import { createUseClassNamesFactory } from 'tss-react/createUseClassNamesFactory';
 
-const { createUseClassNames } = createUseClassNamesFactory({ useTheme });
+// @ts-ignore Fix me, typings are off
+const { createUseClassNames } = createUseClassNamesFactory({ useTheme, css });
 
 const Div = styled('div')({
   border: "1px solid transparent",
@@ -36,7 +39,8 @@ export default function Home() {
   return (
     <Stack direction="row" spacing={2} alignItems="center" justifyContent="center">
       <Div>This div should have green background</Div>
-      <Div className={classNames.root}>This div should have red background</Div>
+      {/* @ts-ignore We should NOT use the `css` prop here. Not sure there are other options...  */}
+      <Div css={classNames.root}>This div should have red background</Div>
     </Stack>
   )
 }


### PR DESCRIPTION
I tried to use the `css` exported from `@emotion/react` inside `createUseClassNamesFactory`, but it requires the usage of the `css` prop instead of `className`. This would be a no-go.

Actually, I am curious whether the @emotion/css package is intended to be used together with @emotion/react & @emotion/styled. Maybe we should start from a simpler project that just uses @emotion/react, @emotion/styled and @emotion/css and see where it will get us.

Related to https://github.com/mnajdova/mui-tss-react-integration/issues/1

We can iterate on different ideas...